### PR TITLE
Typo in run-a-taiko-node.mdx

### DIFF
--- a/src/content/docs/guides/run-a-taiko-node.mdx
+++ b/src/content/docs/guides/run-a-taiko-node.mdx
@@ -32,7 +32,7 @@ You currently **cannot** run a proposer / prover on Taiko's Katla testnet. This 
   <TabItem label="Windows">
     ```sh
     git clone https://github.com/taikoxyz/simple-taiko-node.git
-    cd simple-taiko-node git config core.autocrlf false
+    cd simple-taiko-node && git config core.autocrlf false
     ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Missing '&&' operator between commands to change directory and configure line endings for Windows setup.