### PR TITLE
docs: fix typo on learning resources page

### DIFF
--- a/src/content/docs/resources/learning-resources.md
+++ b/src/content/docs/resources/learning-resources.md
@@ -8,7 +8,7 @@ description: Resource page where we list various useful learning resources.
 - X space: [Based rollups and decentralized sequencing](https://www.youtube.com/watch?v=eS5s08sgjuo).
 - X space: [Based sequencing ft. Justin Drake: Part 2](https://www.youtube.com/watch?v=RqgIEkAfpks).
 
-## Rollup terminiologies
+## Rollup terminologies
 
 - [The Rollup Glossary](https://rollup-glossary.vercel.app).
 - Rollup training wheels: [L2Beat](https://l2beat.com).


### PR DESCRIPTION
Fixes a type on the "Resources" > "Learning resources" page:

Rollup terminiologies

should be:

Rollup terminologies