### PR TITLE
Fix error in code

### DIFF
--- a/src/content/docs/guides/verify-a-contract.md
+++ b/src/content/docs/guides/verify-a-contract.md
@@ -14,8 +14,8 @@ You have a contract deployed on Taiko and the source code available.
 Replace the contract address and filepath to contract below, and then execute in terminal to verify your contract.
 
 ```bash
-forge verify-contract 0x526317252e346978869d178081dA2cd10ac8b56D src/Counter.sol:Counter \
-  --verifier-url https://blockscoutapi.katla.taiko.xyz/api\? \
+forge verify-contract 0x526317252e346978869d178081dA2cd10ac8b56D Counter.sol:Counter \
+  --verifier-url "https://blockscoutapi.katla.taiko.xyz/api" \
   --verifier blockscout
 ```
 


### PR DESCRIPTION
It looks like you're attempting to use the "forge verify-contract" command to verify a smart contract on the BlockScout API. The command structure and parameters appear to be mostly correct, but there are a couple of issues that might be causing it to not work as expected.

First, your --verifier-url parameter seems to have a backslash and question mark that might be causing issues. It should be formatted without the backslash and with the query parameters directly appended to the URL.

Second, the contract address and contract file path should be specified without the "src/" prefix.