### PR TITLE
fix: resolve broken link

### DIFF
--- a/src/content/docs/start-here/contributing.md
+++ b/src/content/docs/start-here/contributing.md
@@ -39,7 +39,7 @@ Before we can consider your contributions, please have a look at the following r
 - Any contribution must follow the standards documented in this file.
 - The scope must be larger than a simple rename, or typo fix. We kindly request that small, incremental updates be combined into more substantial pull requests. This approach will streamline our development and ensure focus on core improvements.
 
-Specify the scope of your change with a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) in the PR title (for example, `feat(scope): description of feature`). This will be squashed and merged into the `main` branch. You can find the full list of allowed scopes [here](https://github.com/taikoxyz/taiko-mono/blob/main/.github/workflows/lint-pr.yml#L19).
+Specify the scope of your change with a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) in the PR title (for example, `feat(scope): description of feature`). This will be squashed and merged into the `main` branch. You can find the full list of allowed scopes [here](https://github.com/taikoxyz/taiko-mono/blob/main/.github/workflows/validate-pr-title.yml#L28).
 
 Because we squash all of the changes into a single commit, please try to keep the PR limited to the scope specified in the commit message. This commit message will end up in the automated changelog by checking which packages are affected by the commit.
 


### PR DESCRIPTION
This pull request addresses a broken link in the `contributing.md` file. The link was leading to a non-existent file, and this change corrects it to point to the correct location.
