### PR TITLE
docs: add a reminder for CLI reference, Update run-a-taiko-node.mdx

### DIFF
--- a/src/content/docs/guides/run-a-taiko-node.mdx
+++ b/src/content/docs/guides/run-a-taiko-node.mdx
@@ -178,6 +178,12 @@ See the video tutorial [Run a Taiko L2 node (YouTube)](https://www.youtube.com/w
 
 ## Full simple-taiko-node CLI reference
 
+Make sure you are in the simple-taiko-node folder. If you are not:
+
+```sh
+cd simple-taiko-node
+```
+
 #### Start node
 
 ```sh


### PR DESCRIPTION
You need to be in the right folder to be able to run the CLI reference. there will be those who forget or skip this. I saw a few questions about this on Discord.

I just added:
`````
Make sure you are in the simple-taiko-node folder. If you are not:

```sh
cd simple-taiko-node
```

`````
