### PR TITLE
fix(docs-interface): little correct cosmetic title links

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -28,3 +28,12 @@
   --sl-color-gray-7: #f5f6f8;
   --sl-color-black: #ffffff;
 }
+
+.site-title a:hover {
+  padding-top: 1%; 
+}
+
+.site-title a:hover svg {
+    --hover-offset:0; 
+}
+


### PR DESCRIPTION
bug or fix not understand maybe only for me but proposal

now (when hovering the cursor, the upper part of the logo and border links docs is cut off)

[Screencast from 2024-03-20 23-29-00.webm](https://github.com/taikoxyz/docs/assets/149963982/82d9051c-4088-4b66-924a-3cdf0f0e88a6)

but this styles make

[Screencast from 2024-03-20 23-51-57.webm](https://github.com/taikoxyz/docs/assets/149963982/6709da1d-2099-4bfe-a510-e859443487f7)

in a word, with these styles the upper part of the logo remains uncut