### PR TITLE
docs: add discord link to faqs

### DIFF
--- a/src/content/docs/resources/faqs.md
+++ b/src/content/docs/resources/faqs.md
@@ -21,7 +21,7 @@ Yes, Taiko is open source under the permissive MIT license (free to access and m
 
 ## Can I ignore these logs from my node?
 
-Join the Discord (`#errors-faq` channel) to see the node logs that can be ignored and which are errors.
+Join the Discord ([`#errors-faq` channel](https://discord.com/channels/984015101017346058/1193975550256107660)) to see the node logs that can be ignored and which are errors.
 
 ## Where can I find the deployed contract addresses?
 


### PR DESCRIPTION
Added link to referenced channel for ease of access when following the guide