### PR TITLE
docs: fix 2 typos in docker compose commands

### DIFF
--- a/src/content/docs/guides/enable-a-proposer.md
+++ b/src/content/docs/guides/enable-a-proposer.md
@@ -24,7 +24,7 @@ description: This guide will you help you enable your Taiko node as a proposer.
 
 5. Finally set `ENABLE_PROPOSER` to `true` in simple-taiko-node `.env`.
 
-6. Now that the proposer is configured properly, you can run it with `docker compose --profile proposer -up -d`!
+6. Now that the proposer is configured properly, you can run it with `docker compose --profile proposer up -d`!
 
 :::note
 These are the bare minimum required settings along with a functional Taiko node to run a proposer, feel free to customize the rest of the variables in the .env file as you see fit!

--- a/src/content/docs/guides/run-a-taiko-node.mdx
+++ b/src/content/docs/guides/run-a-taiko-node.mdx
@@ -133,7 +133,7 @@ This only starts the driver and l2 execution engine service, if you'd like to ru
 :::
 
 ```sh
-docker compose up --profile l2_execution_engine -d
+docker compose --profile l2_execution_engine up -d
 ```
 
 ### 6. Verify node is running


### PR DESCRIPTION
The docker compose syntax was mistyped in 2 snippets